### PR TITLE
Fix type hint in request with uploaded file

### DIFF
--- a/src/RequestFormatter.php
+++ b/src/RequestFormatter.php
@@ -2,7 +2,7 @@
 
 namespace RequestLogger;
 
-use Illuminate\Http\UploadedFile;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class RequestFormatter
 {


### PR DESCRIPTION
**Description**

In some cases Laravel use `Symfony\Component\HttpFoundation\File\UploadedFile` instead of `Illuminate\Http\UploadedFile` and throw error:
```
Argument 1 passed to RequestLogger\RequestFormatter::RequestLogger\{closure}() must be an instance of Illuminate\Http\UploadedFile, instance of Symfony\Component\HttpFoundation\File\UploadedFile given
```


**Breaking changes**

No breaking changes
